### PR TITLE
[4.x] Query Logging Ability

### DIFF
--- a/src/Drivers/LaravelTinkerwellDriver.php
+++ b/src/Drivers/LaravelTinkerwellDriver.php
@@ -44,8 +44,8 @@ class LaravelTinkerwellDriver extends TinkerwellDriver
     }
 
     public function injectQueryLogging($code)
-{
-    $codePrefix = <<<'EOT'
+    {
+        $codePrefix = <<<'EOT'
 try {
     \DB::listen(function($query)
     {
@@ -69,6 +69,6 @@ try {
 } catch (\Throwable $e) {}
 EOT;
 
-    return $codePrefix . PHP_EOL . $code;
-}
+        return $codePrefix.PHP_EOL.$code;
+    }
 }

--- a/src/Drivers/LaravelTinkerwellDriver.php
+++ b/src/Drivers/LaravelTinkerwellDriver.php
@@ -42,4 +42,33 @@ class LaravelTinkerwellDriver extends TinkerwellDriver
             (new \Tinkerwell\Panels\LaravelPanel())->toArray(),
         ];
     }
+
+    public function injectQueryLogging($code)
+{
+    $codePrefix = <<<'EOT'
+try {
+    \DB::listen(function($query)
+    {
+        try {
+            $grammar = $query->connection->getQueryGrammar();
+
+            $properties = method_exists($grammar, 'substituteBindingsIntoRawSql') ? [
+                'sql' => $grammar->substituteBindingsIntoRawSql(
+                    $query->sql,
+                    $query->connection->prepareBindings($query->bindings)
+                ),
+                'bindings' => [],
+            ] : [
+                'sql' => $query->sql,
+                'bindings' => $query->bindings,
+            ];
+            
+            __tinkerwell_query($properties['sql'], $properties['bindings']);
+        } catch (\Throwable $e) {}
+    });
+} catch (\Throwable $e) {}
+EOT;
+
+    return $codePrefix . PHP_EOL . $code;
+}
 }

--- a/src/Drivers/TinkerwellDriver.php
+++ b/src/Drivers/TinkerwellDriver.php
@@ -105,6 +105,11 @@ abstract class TinkerwellDriver
         return null;
     }
 
+    public function injectQueryLogging($code)
+    {
+        return $code;
+    }
+
     public static function getAvailableDrivers()
     {
         return [

--- a/src/Drivers/WordpressTinkerwellDriver.php
+++ b/src/Drivers/WordpressTinkerwellDriver.php
@@ -42,4 +42,20 @@ class WordpressTinkerwellDriver extends TinkerwellDriver
     {
         return false;
     }
+
+    public function injectQueryLogging($code)
+    {
+        $codePrefix = <<<'EOT'
+try {
+    if (! defined('SAVEQUERIES') || ! SAVEQUERIES) {
+        define('SAVEQUERIES', true);
+    }
+    add_filter('log_query_custom_data', function ($data, $query, $timeInSeconds) {
+        __tinkerwell_query($query);
+    }, 1, 3);
+} catch (\Throwable $e) {}
+EOT;
+
+        return $codePrefix . PHP_EOL . $code;
+    }
 }

--- a/src/Drivers/WordpressTinkerwellDriver.php
+++ b/src/Drivers/WordpressTinkerwellDriver.php
@@ -56,6 +56,6 @@ try {
 } catch (\Throwable $e) {}
 EOT;
 
-        return $codePrefix . PHP_EOL . $code;
+        return $codePrefix.PHP_EOL.$code;
     }
 }


### PR DESCRIPTION
Tinkerwell 4 will allow you to show query logs when running your code:

![CleanShot 2023-09-20 at 13 14 16](https://github.com/beyondcode/tinkerwell/assets/804684/a03e3125-4942-43fc-8bee-714d76ea0aca)

The query logging logic is determined by the driver that is used.

This PR adds query logging to the Laravel and the WordPress driver.